### PR TITLE
Fix/display typed values

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,4 +68,8 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.1.0-beta02'
     androidTestImplementation 'androidx.test:rules:1.1.0-beta02'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-beta02'
+
+    def lifecycle_version = "2.2.0"
+    // LiveData
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.1.0-beta02'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-beta02'
 
-    def lifecycle_version = "2.2.0"
     // LiveData
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.2.0"
 }

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
@@ -35,7 +35,7 @@ class MainActivity : SimpleActivity(), Calculator {
 
         calc = CalculatorImpl(this, applicationContext)
         calc.typedValues.observe(this, Observer {
-            if (calc.isFirstEntry()) formula.text = it.joinToString("")
+            if (calc.isFirstEntry() && it.isWithOperationSign()) formula.text = it.joinToString("")
         })
 
         btn_plus.setOnClickListener { calc.handleOperation(PLUS); checkHaptic(it) }
@@ -173,4 +173,8 @@ class MainActivity : SimpleActivity(), Calculator {
     override fun setFormula(value: String, context: Context) {
         formula.text = value
     }
+}
+
+private fun <E> List<E>.isWithOperationSign(): Boolean {
+    return joinToString("").toIntOrNull() == null
 }

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
@@ -7,6 +7,7 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.WindowManager
+import androidx.lifecycle.Observer
 import com.simplemobiletools.calculator.BuildConfig
 import com.simplemobiletools.calculator.R
 import com.simplemobiletools.calculator.extensions.config
@@ -33,6 +34,9 @@ class MainActivity : SimpleActivity(), Calculator {
         appLaunched(BuildConfig.APPLICATION_ID)
 
         calc = CalculatorImpl(this, applicationContext)
+        calc.typedValues.observe(this, Observer {
+            if (calc.isFirstEntry()) formula.text = it.joinToString("")
+        })
 
         btn_plus.setOnClickListener { calc.handleOperation(PLUS); checkHaptic(it) }
         btn_minus.setOnClickListener { calc.handleOperation(MINUS); checkHaptic(it) }

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
@@ -3,6 +3,7 @@ package com.simplemobiletools.calculator.activities
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -11,6 +12,7 @@ import androidx.lifecycle.Observer
 import com.simplemobiletools.calculator.BuildConfig
 import com.simplemobiletools.calculator.R
 import com.simplemobiletools.calculator.extensions.config
+import com.simplemobiletools.calculator.extensions.isWithOperationSign
 import com.simplemobiletools.calculator.extensions.updateViewColors
 import com.simplemobiletools.calculator.helpers.*
 import com.simplemobiletools.commons.extensions.*
@@ -34,8 +36,9 @@ class MainActivity : SimpleActivity(), Calculator {
         appLaunched(BuildConfig.APPLICATION_ID)
 
         calc = CalculatorImpl(this, applicationContext)
-        calc.typedValues.observe(this, Observer {
-            if (calc.isFirstEntry() && it.isWithOperationSign()) formula.text = it.joinToString("")
+        calc.typedValues.observe(this, Observer { list ->
+            Log.i("ANGELINA", "observe: $list")
+            formula.text = if (calc.isFirstEntry() && list.isWithOperationSign()) list.joinToString("") else ""
         })
 
         btn_plus.setOnClickListener { calc.handleOperation(PLUS); checkHaptic(it) }
@@ -173,8 +176,4 @@ class MainActivity : SimpleActivity(), Calculator {
     override fun setFormula(value: String, context: Context) {
         formula.text = value
     }
-}
-
-private fun <E> List<E>.isWithOperationSign(): Boolean {
-    return joinToString("").toIntOrNull() == null
 }

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/extensions/Extensions.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/extensions/Extensions.kt
@@ -1,0 +1,5 @@
+package com.simplemobiletools.calculator.extensions
+
+inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> safeLet(p1: T1?, p2: T2?, p3: T3?, block: (T1, T2, T3) -> R?): R? {
+    return if (p1 != null && p2 != null && p3 != null) block(p1, p2, p3) else null
+}

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/extensions/Extensions.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/extensions/Extensions.kt
@@ -3,3 +3,7 @@ package com.simplemobiletools.calculator.extensions
 inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> safeLet(p1: T1?, p2: T2?, p3: T3?, block: (T1, T2, T3) -> R?): R? {
     return if (p1 != null && p2 != null && p3 != null) block(p1, p2, p3) else null
 }
+
+fun <E> List<E>.isWithOperationSign(): Boolean {
+    return joinToString("").toIntOrNull() == null
+}

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -3,6 +3,7 @@ package com.simplemobiletools.calculator.helpers
 import android.content.Context
 import androidx.lifecycle.MutableLiveData
 import com.simplemobiletools.calculator.R
+import com.simplemobiletools.calculator.extensions.isWithOperationSign
 import com.simplemobiletools.calculator.extensions.safeLet
 import com.simplemobiletools.calculator.operation.OperationFactory
 
@@ -169,7 +170,13 @@ class CalculatorImpl(private val callback: Calculator, private val context: Cont
     }
 
     fun handleClear() {
-        if (displayedNumber.equals(NAN)) {
+        if (typedValues.value?.isWithOperationSign() == true && isFirstEntry()) {
+            /* remove the operation sign */
+            typedValues.value?.let { oldList ->
+                if (oldList?.size > 1) typedValues.value = oldList?.subList(0, oldList.lastIndex)
+                lastOperation = ""
+            }
+        } else if (displayedNumber.equals(NAN)) {
             handleReset()
         } else {
             val oldValue = displayedNumber


### PR DESCRIPTION
https://trello.com/c/6g5B07gF/7-calculator-show-current-operation-at-the-top

The initial values are not displayed on the top part of the screen (formula). Formula view is populated only when the 1st result is calculated. In this fix we populate this view with values before the first result is computed, and then only after the calculator is reset.