### PR TITLE
Fix division by zero bug

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -147,6 +147,10 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
 
         secondValue = getSecondValue()
         calculateResult()
+        if (lastOperation == DIVIDE && secondValue == 0.0){
+            lastKey = DIGIT
+            return
+        }
         lastKey = EQUALS
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -147,7 +147,7 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
 
         secondValue = getSecondValue()
         calculateResult()
-        if (lastOperation == DIVIDE && secondValue == 0.0){
+        if (lastOperation == DIVIDE && secondValue == 0.0) {
             lastKey = DIGIT
             return
         }

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -147,7 +147,7 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
 
         secondValue = getSecondValue()
         calculateResult()
-        if (lastOperation == DIVIDE && secondValue == 0.0) {
+        if ( (lastOperation == DIVIDE || lastOperation == PERCENT) && secondValue == 0.0) {
             lastKey = DIGIT
             return
         }

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -147,10 +147,11 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
 
         secondValue = getSecondValue()
         calculateResult()
-        if ( (lastOperation == DIVIDE || lastOperation == PERCENT) && secondValue == 0.0) {
+        if ((lastOperation == DIVIDE || lastOperation == PERCENT) && secondValue == 0.0) {
             lastKey = DIGIT
             return
         }
+
         lastKey = EQUALS
     }
 


### PR DESCRIPTION
This should resolve issue #202. 

With this fix, is still shown the error for division by zero with the toast, but after that is still possible to change the last inserted digit in order to replace the zero value. So lastOperation variable won't turn into a plus operator anymore. 