### PR TITLE
Fix percentage calculation after mod result 

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -223,6 +223,10 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
                 val partial = baseValue / (100 / secondValue)
                 baseValue.minus(partial)
             }
+            PERCENT -> {
+                val partial = (baseValue % secondValue) / 100
+                partial
+            }
             else -> baseValue / (100 * secondValue)
         }
     }


### PR DESCRIPTION
This should resolve issue #204.

With this fix, after the mod calculation, should be returned the correct percentage result. In order to solve it, I've simply added a new case inside the calculatePercentage() function, because the default one didn't fit correctly the mod needs.