### PR TITLE
turn number to negative on minus-btn long-press

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
@@ -42,6 +42,10 @@ class MainActivity : SimpleActivity(), Calculator {
         btn_power.setOnClickListener { calc.handleOperation(POWER); checkHaptic(it) }
         btn_root.setOnClickListener { calc.handleOperation(ROOT); checkHaptic(it) }
 
+        btn_minus.setOnLongClickListener {
+            calc.turnToNegative();
+        }
+
         btn_clear.setOnClickListener { calc.handleClear(); checkHaptic(it) }
         btn_clear.setOnLongClickListener { calc.handleReset(); true }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/activities/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : SimpleActivity(), Calculator {
         btn_root.setOnClickListener { calc.handleOperation(ROOT); checkHaptic(it) }
 
         btn_minus.setOnLongClickListener {
-            calc.turnToNegative();
+            calc.turnToNegative()
         }
 
         btn_clear.setOnClickListener { calc.handleClear(); checkHaptic(it) }

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -124,12 +124,15 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
     }
 
     fun turnToNegative(): Boolean {
-        // turn to negative only if there is a baseValue alone ( not 0 )
+        if (inputDisplayedFormula.isEmpty()) {
+            return false
+        }
+
         if (!inputDisplayedFormula.trimStart('-').any { it.toString() in operations } && inputDisplayedFormula.replace(",", "").toDouble() != 0.0) {
-            if (inputDisplayedFormula.first() == '-') {
-                inputDisplayedFormula = inputDisplayedFormula.substring(1)
+            inputDisplayedFormula = if (inputDisplayedFormula.first() == '-') {
+                inputDisplayedFormula.substring(1)
             } else {
-                inputDisplayedFormula = "-$inputDisplayedFormula"
+                "-$inputDisplayedFormula"
             }
 
             showNewResult(inputDisplayedFormula)

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -123,18 +123,19 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
         showNewResult(inputDisplayedFormula)
     }
 
-    fun turnToNegative() : Boolean{
+    fun turnToNegative(): Boolean {
         // turn to negative only if there is a baseValue alone ( not 0 )
-        if (!inputDisplayedFormula.trimStart('-').any { it.toString() in operations } && inputDisplayedFormula.replace(",", "").toDouble() != 0.0){
-
-            if(inputDisplayedFormula.first() == '-') {
+        if (!inputDisplayedFormula.trimStart('-').any { it.toString() in operations } && inputDisplayedFormula.replace(",", "").toDouble() != 0.0) {
+            if (inputDisplayedFormula.first() == '-') {
                 inputDisplayedFormula = inputDisplayedFormula.substring(1)
-            }else{
+            } else {
                 inputDisplayedFormula = "-$inputDisplayedFormula"
             }
+
             showNewResult(inputDisplayedFormula)
             return true
         }
+
         return false
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -123,6 +123,21 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
         showNewResult(inputDisplayedFormula)
     }
 
+    fun turnToNegative() : Boolean{
+        // turn to negative only if there is a baseValue alone ( not 0 )
+        if (!inputDisplayedFormula.trimStart('-').any { it.toString() in operations } && inputDisplayedFormula.replace(",", "").toDouble() != 0.0){
+
+            if(inputDisplayedFormula.first() == '-') {
+                inputDisplayedFormula = inputDisplayedFormula.substring(1)
+            }else{
+                inputDisplayedFormula = "-$inputDisplayedFormula"
+            }
+            showNewResult(inputDisplayedFormula)
+            return true
+        }
+        return false
+    }
+
     // handle percents manually, it doesn't seem to be possible via net.objecthunter:exp4j. "%" is used only for modulo there
     private fun handlePercent() {
         var result = calculatePercentage(baseValue, getSecondValue(), lastOperation)


### PR DESCRIPTION
Solves issue #186. When long-pressing the minus_btn the number turns to negative (or positive). If the conversion is not allowed then the long-click is handled like a click.

Sample:
https://user-images.githubusercontent.com/56542304/131219293-7265bd43-9037-496e-b2a1-7f597349e003.mp4

 