### PR TITLE
Fix small bugs

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -252,6 +252,10 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
                 val partial = baseValue / (100 / secondValue)
                 baseValue.minus(partial)
             }
+            PERCENT -> {
+                val partial = (baseValue % secondValue) / 100
+                partial
+            }
             else -> baseValue / (100 * secondValue)
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -111,15 +111,44 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
                 calculateResult()
 
                 if (!operations.contains(inputDisplayedFormula.last().toString())) {
-                    if (!inputDisplayedFormula.contains("÷")) {
+                    if (!inputDisplayedFormula.contains("÷") &&
+                        !inputDisplayedFormula.contains("%")) {
                         inputDisplayedFormula += getSign(operation)
                     }
                 }
             }
         }
+        when (getSecondValue()) {
+            0.0 -> {
+                when (inputDisplayedFormula.contains("÷")) {
+                    true -> {
+                        lastKey = DIVIDE
+                        lastOperation = DIVIDE
+                    }
+                    else -> {
+                        when (inputDisplayedFormula.contains("%")) {
+                            true -> {
+                                lastKey = PERCENT
+                                lastOperation = PERCENT
+                            }
+                            else -> {
+                                lastKey = operation
+                                lastOperation = operation
+                            }
+                        }
 
-        lastKey = operation
-        lastOperation = operation
+
+                    }
+                }
+            }
+            else-> {
+                lastKey = operation
+                lastOperation = operation
+            }
+         }
+
+
+
         showNewResult(inputDisplayedFormula)
     }
 
@@ -184,7 +213,7 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
             val sign = getSign(lastOperation)
             val expression = "${baseValue.format()}$sign${secondValue.format()}".replace("√", "sqrt").replace("×", "*").replace("÷", "/")
             try {
-                if (sign == "÷" && secondValue == 0.0) {
+                if ((sign == "÷" || sign == "%") && secondValue == 0.0) {
                     context.toast(R.string.formula_divide_by_zero_error)
                     return
                 }
@@ -268,16 +297,13 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
         PERCENT -> "%"
         POWER -> "^"
         ROOT -> "√"
-        else -> "+"
+        PLUS -> "+"
+        else -> lastOperation
     }
 
     fun numpadClicked(id: Int) {
         if (inputDisplayedFormula == Double.NaN.toString()) {
             inputDisplayedFormula = ""
-        }
-
-        if (lastKey == EQUALS) {
-            lastOperation = EQUALS
         }
 
         lastKey = DIGIT


### PR DESCRIPTION
**This pull request fixes the following issues:**

1.  Fix  #201 
-[BUG] Sign on display doesn't change after division by zero or mod 0

Now we don't allow to users to change/enter the sign after division/mod 0, it remains "÷" or "%" respectievly.
Users only can insert new denomiator for division operation.

2.  Fix #202 
-[BUG] Sign wrong changing to plus after division by zero

The issue was caused by getSign() function, in which if lastOperation was not defined we assigned result to "+" in else branch of "when" statement 
Now we don't allow to users to change the sign but only the denominator for division.

3. Fix #204
-[BUG] Mod wrong result

Now the result of the n%n% is zero.

4. Fix #218
-[BUG] Crash after putting second sign after mod 0

Now we do not allow to users to put any sign after displaying the error message in case of mod 0.
Users only can insert the second value for mod operation.

-------------------------------------------------------------------------------------------

 #201 and #202 fixed
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/55892883/135128530-bc22c42d-4d9a-43f1-87a6-ed110336e57a.gif)

#204 fixed
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/55892883/135129383-125c5028-aa09-4ff8-9c48-8d10531e70d4.gif)

#218 fixed
![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/55892883/135133598-a2340f34-ab05-4db3-a26b-b871a6b633c7.gif)

