### PR TITLE
Fixed inserting zero after using clear

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -288,9 +288,26 @@ class CalculatorImpl(calculator: Calculator, private val context: Context) {
     }
 
     fun handleClear() {
+        val lastDeletedValue = inputDisplayedFormula.last().toString()
         var newValue = inputDisplayedFormula.dropLast(1)
         if (newValue == "") {
             newValue = "0"
+        } else {
+            if (operations.contains(lastDeletedValue) || lastKey == EQUALS) {
+                lastOperation = ""
+            }
+            val lastValue = newValue.last().toString()
+            lastKey = when {
+                operations.contains(lastValue) -> {
+                    CLEAR
+                }
+                lastValue == "." -> {
+                    DECIMAL
+                }
+                else -> {
+                    DIGIT
+                }
+            }
         }
 
         newValue = newValue.trimEnd(',')


### PR DESCRIPTION
Hi,

I've fixed a few issues related to using the clear button.
- Possibly it fixes the issue #235, but I'm not sure. I can't reproduce it by steps that the original issuer has provided, but it looks related.
- First bug fixed: after clearing value after operator, it wasn't possible to change the operator without creating a new formula with zero.
- Second bug fixed: after clearing operator, it wasn't possible to set operator. Same behavior as in previous bug.
- Related bug (not shown on video), but fix was in the same place: after entering some formula, multiple clicking of equals button was repeating the second part of the formula, what is correct. However, after using clear button, it was treating the new value as both first and second one. I assumed that in such case, the equals button shouldn't work until the user provides an operator and second value.

**Before:**

https://user-images.githubusercontent.com/85929121/149663889-e27178af-fa11-4ee7-8363-944150f49572.mp4

**After:**

https://user-images.githubusercontent.com/85929121/149663901-219f7c5f-0139-45f2-b038-6bc9e0ae339d.mp4
