### PR TITLE
Fixed issue #261 of 0√

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/calculator/helpers/CalculatorImpl.kt
@@ -324,8 +324,9 @@ class CalculatorImpl(
         val lastDeletedValue = inputDisplayedFormula.lastOrNull().toString()
 
         var newValue = inputDisplayedFormula.dropLast(1)
-        if (newValue == "") {
+        if (newValue == "" || newValue == "0") {
             newValue = "0"
+            lastKey = CLEAR
         } else {
             if (operations.contains(lastDeletedValue) || lastKey == EQUALS) {
                 lastOperation = ""


### PR DESCRIPTION
**Cause** : 
lastKey was not updated when newValue became null on clear `C`. 
Hence lastKey validation at line 95 `if (lastKey != DIGIT) {` failed.
**Fix** : 
 lastKey should be CLEAR , whenever newValue becomes null or 0 after `C`.

**TestCases**:
1. Start calc > `C` > `√`
2. Hold `C` > `5*0` > `+` > `C` > `√`