### PR TITLE
Disable RTL in calculator view

### DIFF
--- a/app/src/main/res/layout-land/activity_main.xml
+++ b/app/src/main/res/layout-land/activity_main.xml
@@ -30,6 +30,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:hapticFeedbackEnabled="true"
+        android:layoutDirection="ltr"
         android:orientation="vertical"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 

--- a/app/src/main/res/layout/history_view.xml
+++ b/app/src/main/res/layout/history_view.xml
@@ -12,15 +12,17 @@
 
     <TextView
         android:id="@+id/item_formula"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/medium_margin"
         android:alpha="0.6"
         android:ellipsize="end"
         android:maxLines="1"
         android:paddingStart="@dimen/small_margin"
+        android:paddingEnd="@dimen/small_margin"
+        android:textDirection="ltr"
         android:textSize="@dimen/bigger_text_size"
-        tools:text="2 + 2" />
+        tools:text="4 + 2" />
 
     <TextView
         android:id="@+id/item_result"
@@ -31,7 +33,9 @@
         android:ellipsize="end"
         android:maxLines="1"
         android:paddingStart="@dimen/small_margin"
+        android:paddingEnd="@dimen/small_margin"
+        android:textDirection="ltr"
         android:textSize="@dimen/big_text_size"
-        tools:text="4" />
+        tools:text="-42" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/view_calculator.xml
+++ b/app/src/main/res/layout/view_calculator.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:hapticFeedbackEnabled="true"
+    android:layoutDirection="ltr"
     android:orientation="vertical"
     tools:ignore="HardcodedText">
 


### PR DESCRIPTION
Closes https://github.com/SimpleMobileTools/Simple-Calculator/issues/275

Also fixed an issue with negative numbers in RTL layout (the sign was displayed on the wrong side, only in history)