### PR TITLE
Fixed a typo: in the strings.xml the string for millisecond was set to microsecond in most languages

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">أسبوع</string>
     <string name="unit_time_year">السنة</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -94,7 +94,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-ckb/strings.xml
+++ b/app/src/main/res/values-ckb/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Stunde</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Sekunde</string>
-    <string name="unit_time_millisecond">Mikrosekunde</string>
+    <string name="unit_time_millisecond">Millisekunde</string>
     <string name="unit_time_day">Tag</string>
     <string name="unit_time_week">Woche</string>
     <string name="unit_time_year">Jahr</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hora</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Segundo</string>
-    <string name="unit_time_millisecond">Microsegundo</string>
+    <string name="unit_time_millisecond">Milisegundo</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Semana</string>
     <string name="unit_time_year">Año</string>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Tund</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Sekund</string>
-    <string name="unit_time_millisecond">Mikrosekund</string>
+    <string name="unit_time_millisecond">Millisekund</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Nädal</string>
     <string name="unit_time_year">Aasta</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -89,7 +89,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Heure</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Seconde</string>
-    <string name="unit_time_millisecond">Microseconde</string>
+    <string name="unit_time_millisecond">Milliseconde</string>
     <string name="unit_time_day">Jour</string>
     <string name="unit_time_week">Semaine</string>
     <string name="unit_time_year">Année</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -89,7 +89,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Óra</string>
     <string name="unit_time_minute">Perc</string>
     <string name="unit_time_second">Másodperc</string>
-    <string name="unit_time_millisecond">Mikromásodperc</string>
+    <string name="unit_time_millisecond">Millimásodperc</string>
     <string name="unit_time_day">Nap</string>
     <string name="unit_time_week">Hét</string>
     <string name="unit_time_year">Év</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-kn/strings.xml
+++ b/app/src/main/res/values-kn/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-kr/strings.xml
+++ b/app/src/main/res/values-kr/strings.xml
@@ -94,7 +94,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-mk/strings.xml
+++ b/app/src/main/res/values-mk/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -94,7 +94,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Uur</string>
     <string name="unit_time_minute">Minuut</string>
     <string name="unit_time_second">Seconde</string>
-    <string name="unit_time_millisecond">Microseconde</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Dag</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Jaar</string>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-or/strings.xml
+++ b/app/src/main/res/values-or/strings.xml
@@ -96,7 +96,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-pa-rPK/strings.xml
+++ b/app/src/main/res/values-pa-rPK/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Godzina</string>
     <string name="unit_time_minute">Minuta</string>
     <string name="unit_time_second">Sekunda</string>
-    <string name="unit_time_millisecond">Mikrosekunda</string>
+    <string name="unit_time_millisecond">Milisekunda</string>
     <string name="unit_time_day">Dzień</string>
     <string name="unit_time_week">Tydzień</string>
     <string name="unit_time_year">Rok</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hora</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Segundo</string>
-    <string name="unit_time_millisecond">Microssegundo</string>
+    <string name="unit_time_millisecond">Milissegundo</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Semana</string>
     <string name="unit_time_year">Ano</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Час</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Секунда</string>
-    <string name="unit_time_millisecond">Микросекунда</string>
+    <string name="unit_time_millisecond">Миллисекунда</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Неделя</string>
     <string name="unit_time_year">Год</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hodina</string>
     <string name="unit_time_minute">Minúta</string>
     <string name="unit_time_second">Sekunda</string>
-    <string name="unit_time_millisecond">Mikrosekunda</string>
+    <string name="unit_time_millisecond">Milisekunda</string>
     <string name="unit_time_day">Deň</string>
     <string name="unit_time_week">Týždeň</string>
     <string name="unit_time_year">Rok</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -89,7 +89,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Timme</string>
     <string name="unit_time_minute">Minut</string>
     <string name="unit_time_second">Sekund</string>
-    <string name="unit_time_millisecond">Mikrosekund</string>
+    <string name="unit_time_millisecond">Millisekund</string>
     <string name="unit_time_day">Dag</string>
     <string name="unit_time_week">Vecka</string>
     <string name="unit_time_year">År</string>

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -95,7 +95,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Saat</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Saniye</string>
-    <string name="unit_time_millisecond">Mikrosaniye</string>
+    <string name="unit_time_millisecond">Milisaniye</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Hafta</string>
     <string name="unit_time_year">Yıl</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-zgh/strings.xml
+++ b/app/src/main/res/values-zgh/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">小时</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">秒</string>
-    <string name="unit_time_millisecond">微秒</string>
+    <string name="unit_time_millisecond">毫秒</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">周</string>
     <string name="unit_time_year">年</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -92,7 +92,7 @@
     <string name="unit_time_hour">小時</string>
     <string name="unit_time_minute">分鐘</string>
     <string name="unit_time_second">秒</string>
-    <string name="unit_time_millisecond">微秒</string>
+    <string name="unit_time_millisecond">毫秒</string>
     <string name="unit_time_day">天</string>
     <string name="unit_time_week">週</string>
     <string name="unit_time_year">年</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,7 +96,7 @@
     <string name="unit_time_hour">Hour</string>
     <string name="unit_time_minute">Minute</string>
     <string name="unit_time_second">Second</string>
-    <string name="unit_time_millisecond">Microsecond</string>
+    <string name="unit_time_millisecond">Millisecond</string>
     <string name="unit_time_day">Day</string>
     <string name="unit_time_week">Week</string>
     <string name="unit_time_year">Year</string>


### PR DESCRIPTION
Everything except for ca and el is fixed now. idk about these two. Languages where the string was in English remain in English.